### PR TITLE
Added 'Getting Help' section

### DIFF
--- a/getting-help/office-hours.rst
+++ b/getting-help/office-hours.rst
@@ -1,0 +1,32 @@
+.. _getting-help_office-hours:
+
+Office Hours
+============
+
+Most CS classes will have office hours where you can get assistance
+with your coursework, or have broader-ranging conversations about
+the material covered in the class. In this page, we provide
+a few tips on how to get the most out of office hours.
+
+- First and foremost, some words of encouragement. Know that the course staff
+  is there to help you, and they cannot help you if you do not
+  ask questions. Quite simply, the point is to learn, not to
+  know everything already.
+- Sometimes, office hours are run as a sort of "Q&A session" where
+  multiple students are in the room at the same time, and an instructor
+  or TA takes questions from the students. In these kind of office hours,
+  chances are someone else has a similar
+  question to the one you want to ask. In attending office hours,
+  you may get an answer to your question without having to ask it yourself.
+- Prepare questions ahead of time. Time in office hours can be
+  limited–particularly near exams–and so knowing what you need help
+  with beforehand will let you make the most of your time.
+- Make a list of known unknowns. Along the lines of the previous point,
+  knowing what you do not fully understand is a time saver.
+- When formulating your questions try to make them specific and clear.
+  The course staff cannot help you if they do not know what you are
+  talking about.
+- On days when there are not a lot of pressing questions during office
+  hours, you can just talk to the course staff and faculty about what you
+  find interesting about the material. It can be outside the scope of what
+  was covered in class.

--- a/getting-help/office-hours.rst
+++ b/getting-help/office-hours.rst
@@ -19,13 +19,12 @@ a few tips on how to get the most out of office hours.
   question to the one you want to ask. In attending office hours,
   you may get an answer to your question without having to ask it yourself.
 - Prepare questions ahead of time. Time in office hours can be
-  limited–particularly near exams–and so knowing what you need help
+  limited–particularly near assignments deadlines and exams–and so knowing what you need help
   with beforehand will let you make the most of your time.
 - Make a list of known unknowns. Along the lines of the previous point,
   knowing what you do not fully understand is a time saver.
 - When formulating your questions try to make them specific and clear.
-  The course staff cannot help you if they do not know what you are
-  talking about.
+  The course staff cannot help you if they do not understand your question.
 - On days when there are not a lot of pressing questions during office
   hours, you can just talk to the course staff and faculty about what you
   find interesting about the material. It can be outside the scope of what

--- a/getting-help/questions.rst
+++ b/getting-help/questions.rst
@@ -4,9 +4,10 @@ Asking Questions
 ================
 
 As you work through your coursework, many of you will probably have
-questions or will encounter issues that you are not sure how to deal
-with. Your course staff will typically set up some form of online discussion board
-for this very purpose, usually through Canvas or Ed Discussion.
+questions or will encounter issues that you are not sure how to
+handle. Your course staff will typically set up some form of online
+discussion board for this very purpose, usually through Canvas or Ed
+Discussion.
 
 Online discussion boards provide a
 convenient mechanism to ask questions, but it can sometimes be
@@ -25,7 +26,7 @@ help you ask questions more effectively on an online discussion board:
       you could search just for that test’s name to see if any
       other students have encountered that same error (and, if you’re
       lucky, an instructor/TA will have already answered it).
-   -  **Make sure you’re going to ask an actual question**. Make sure
+   -  **Make sure to formulate an actual question to ask**. Make sure
       you are describing a specific issue you’re encountering, and why you’re
       stuck on it (e.g., you are not getting the expected result, the
       tests are failing in a way you do not understand, etc.). Writing a
@@ -46,7 +47,7 @@ help you ask questions more effectively on an online discussion board:
 
   Of course, when you run into an issue on an assignment, it may seem like
   "it applies only to you" because it relates to your code. However,
-  it's possible tha other students will run into the exact same issue
+  it's possible that other students will run into the exact same issue
   you ran into. So, questions about coursework, course logistics, etc.
   do not qualify as "private matters", and should typically be
   asked publicly. This way, everyone can benefit from the
@@ -66,9 +67,10 @@ help you ask questions more effectively on an online discussion board:
   you’re encountering). And to do so, they need as much information as
   possible from you:
 
-   -  If your question relates to your code, and your class uses GitHub
-      repositories, make sure you push your code to GitHub before asking for help.
-   -  Make sure you’re running your code on a :ref:`UChicago CS software environment <software-environment>`
+   - If your question relates to your code, and your class is using a
+     version-control system (e.g. git, svn, etc), make
+     sure you push your code to the server (e.g. GitHub, GitLab, PhoenixForge) before asking for help.
+   -  Make sure you’re running your code on a :ref:`UChicago CS software environment <software-environment>`.
       Course staff will not be able to provide
       assistance if you are running your code on your personal machine,
       as this will make it harder for them to reproduce the exact issue
@@ -79,11 +81,10 @@ help you ask questions more effectively on an online discussion board:
       run a test? Etc.).
    -  If you encounter an error message (or any other unexpected output)
       when running a command or a specific test, please make sure you
-      include the **full and unabridged** error message (or unexpected
+      include the command that you ran and the **full and unabridged** error message (or unexpected
       output). Summarizing the message (e.g., “The tests says it was
       expecting value 42, and I’m pretty sure that’s what I’m
-      returning”) makes it harder for course staff to figure out what the issue
-      is.
+      returning”) makes it harder for course staff to identify the issue.
    -  If something is “wrong”, please describe in what way it seems
       wrong to you. For example, were you expecting a particular output
       but got a different one? Is a piece of code behaving in a way you
@@ -94,13 +95,14 @@ help you ask questions more effectively on an online discussion board:
 
    -  **Never post your code on an online discussion board**. If
       you need the course staff to look at your code, and your class
-      uses Git repositories, just push it to GitHub and the course staff
+      uses a version control system, just push it to the server
+      (e.g. GitHub, GitLab, PhoenixForge) and the course staff
       will look at it there. Please note that, if a test prints out a
-      few lines of code as part of its output, that is typically ok.
-   -  **No screenshots**. Do not post screenshots of the output.
+      few lines of code as part of its output, that is typically acceptable.
+   -  **No screenshots**. Do not post screenshots of the command or the output.
       Screenshots are not searchable, and may pose readability issues
-      for some people. Instructors/TAs may also want to copy-paste that
-      output somewhere else, which is not possible if you post a
+      for some people. Instructors/TAs may also want to copy-paste your
+      command elsewhere, which is not possible if you post a
       screenshot.
 
       If you need to share some output from the terminal, copy-paste from the
@@ -108,7 +110,7 @@ help you ask questions more effectively on an online discussion board:
       “code block” or "verbatim" formatting. To copy something on the terminal, just
       select it (the same way you would do in a word processor: click,
       and then drag until the end of the output) and press
-      Control-Shift-C.
+      Control-Shift-C (Command-C on MacOS).
 
 -  **One question, one post**. Avoid posts that have multiple unrelated
    questions. Instead, write a separate post for each question. Please

--- a/getting-help/questions.rst
+++ b/getting-help/questions.rst
@@ -1,0 +1,124 @@
+.. _getting-help_questions:
+
+Asking Questions
+================
+
+As you work through your coursework, many of you will probably have
+questions or will encounter issues that you are not sure how to deal
+with. Your course staff will typically set up some form of online discussion board
+for this very purpose, usually through Canvas or Ed Discussion.
+
+Online discussion boards provide a
+convenient mechanism to ask questions, but it can sometimes be
+challenging for course staff to help you if you do not provide the right
+information when asking a question. Here are a few suggestions that may
+help you ask questions more effectively on an online discussion board:
+
+-  Before you post a question...
+
+   -  **Search before asking**. Before posting a question on the
+      discussion board, check whether it has already been answered in a
+      previous post. We realize the volume of posts can be overwhelming,
+      but you should start by using the discussion board’s search
+      functionality to see if it brings up any relevant posts. For
+      example, suppose you are failing a specific test in a programming assignment;
+      you could search just for that test’s name to see if any
+      other students have encountered that same error (and, if you’re
+      lucky, an instructor/TA will have already answered it).
+   -  **Make sure you’re going to ask an actual question**. Make sure
+      you are describing a specific issue you’re encountering, and why you’re
+      stuck on it (e.g., you are not getting the expected result, the
+      tests are failing in a way you do not understand, etc.). Writing a
+      post that says “I can’t get Task 4 to work, I’ve pushed my code.
+      Please look at it.” is not a question: it is a request for someone
+      to debug your code for you. Try instead to describe the exact
+      reason why you're stuck (we provide concrete suggestions on how to
+      do this below). If you're struggling to do so, you may want to
+      go to :ref:`office hours <getting-help_office-hours>` to get help
+      more interactively.
+
+- **Public vs private questions**. Discussion boards often have
+  mechanisms that allow you to ask private questions, which will be
+  seen only by the instructors and teaching assistants. Typically, this
+  mechanism should be used only for truly private matters that relate
+  uniquely to you (e.g., you need to notify the course staff of a family/medical
+  emergency, etc.).
+
+  Of course, when you run into an issue on an assignment, it may seem like
+  "it applies only to you" because it relates to your code. However,
+  it's possible tha other students will run into the exact same issue
+  you ran into. So, questions about coursework, course logistics, etc.
+  do not qualify as "private matters", and should typically be
+  asked publicly. This way, everyone can benefit from the
+  answer to the question and, if someone runs into the same issue you
+  do, course staff can refer them to the answer they provided in your post.
+
+- **The more information, the better**. We know that, in some
+  classes, you may feel the need to be brief and concise when asking
+  for help to “avoid wasting the professor’s time” or because
+  “professors don’t have time to read long e-mails”. The absolute
+  opposite is true in most CS classes: when asking for help, we prefer
+  that you *overwhelm* us with information.
+
+  In particular, it will be much easier for course staff to help you if they are
+  able to reproduce the exact issue you are encountering (i.e., when
+  they run your code, they must be able to observe the exact same issue
+  you’re encountering). And to do so, they need as much information as
+  possible from you:
+
+   -  If your question relates to your code, and your class uses GitHub
+      repositories, make sure you push your code to GitHub before asking for help.
+   -  Make sure you’re running your code on a :ref:`UChicago CS software environment <software-environment>`
+      Course staff will not be able to provide
+      assistance if you are running your code on your personal machine,
+      as this will make it harder for them to reproduce the exact issue
+      you are encountering.
+   -  Include a detailed description of the exact chain of events that
+      lead to the issue you’re encountering (Are you testing a specific
+      function? If so, with what inputs? Does the issue come up when you
+      run a test? Etc.).
+   -  If you encounter an error message (or any other unexpected output)
+      when running a command or a specific test, please make sure you
+      include the **full and unabridged** error message (or unexpected
+      output). Summarizing the message (e.g., “The tests says it was
+      expecting value 42, and I’m pretty sure that’s what I’m
+      returning”) makes it harder for course staff to figure out what the issue
+      is.
+   -  If something is “wrong”, please describe in what way it seems
+      wrong to you. For example, were you expecting a particular output
+      but got a different one? Is a piece of code behaving in a way you
+      were not expecting? Etc. It can be useful to describe what you were
+      expecting the code to do, and what you encountered instead.
+
+- What *not* to include in your question:
+
+   -  **Never post your code on an online discussion board**. If
+      you need the course staff to look at your code, and your class
+      uses Git repositories, just push it to GitHub and the course staff
+      will look at it there. Please note that, if a test prints out a
+      few lines of code as part of its output, that is typically ok.
+   -  **No screenshots**. Do not post screenshots of the output.
+      Screenshots are not searchable, and may pose readability issues
+      for some people. Instructors/TAs may also want to copy-paste that
+      output somewhere else, which is not possible if you post a
+      screenshot.
+
+      If you need to share some output from the terminal, copy-paste from the
+      terminal onto the discussion board, and use the discussion board’s
+      “code block” or "verbatim" formatting. To copy something on the terminal, just
+      select it (the same way you would do in a word processor: click,
+      and then drag until the end of the output) and press
+      Control-Shift-C.
+
+-  **One question, one post**. Avoid posts that have multiple unrelated
+   questions. Instead, write a separate post for each question. Please
+   note that it is ok to ask multiple questions in one post if they all
+   relate to the same issue.
+
+-  **Comments vs Answers**. Some discussion board distinguish between
+   "answering" a question and adding a "comment" on an existing question.
+   In those cases, you should use the "comment" functionality if you'd like
+   to provide additional information on a question, or have a follow-up question.
+   You should use the "answer" functionality only if you are providing an
+   actual answer to the question (including if you've resolved the issue
+   on your own, so the question is flagged as "answered").

--- a/index.rst
+++ b/index.rst
@@ -47,6 +47,14 @@ This guide is divided into four sections:
 .. toctree::
    :maxdepth: 2
    :hidden:
+   :caption: Getting Help
+
+   Asking Questions <getting-help/questions.rst>
+   Office Hours <getting-help/office-hours.rst>
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
    :caption: Style Guides
 
    C <style_guide/c.rst>

--- a/index.rst
+++ b/index.rst
@@ -47,7 +47,7 @@ This guide is divided into four sections:
 .. toctree::
    :maxdepth: 2
    :hidden:
-   :caption: Getting Help
+   :caption: Getting Help in Your Classes
 
    Asking Questions <getting-help/questions.rst>
    Office Hours <getting-help/office-hours.rst>


### PR DESCRIPTION
I've added a new section called 'Getting Help' that includes two pages:

- **Asking Questions**: A generalized version of the question-asking guidelines we've provided in a number of classes.
- **Office Hours**: Tips/suggestions on how to get the most out of office hours.

We also need some sort of "getting help with this guide" page, but I'm not sure whether we want to put it in this section (which is supposed to be about how to get help in your classes), or under "About This Guide" (in PR #13). If the latter, calling the page "Getting Help" might be confusing, so we should think of a different name.