### PR TITLE
Added text on case sensitivity to ssh document

### DIFF
--- a/environment/ssh.rst
+++ b/environment/ssh.rst
@@ -82,7 +82,7 @@ typing ``Ctrl-D`` or ``exit`` at the Linux prompt.
 
 .. note:: Troubleshooting UChicago Campus Network Issues
 
-   There are at least three wireless networks on campus: ``uchicago-secure``, ``eduroam``, ``uchicago``. The first two–``uchicago-secure`` and ``eduroam``–can be used with ``ssh``. The third–``uchicago``– CANNOT does not support ``ssh`` connections.
+   There are at least three wireless networks on campus: ``uchicago-secure``, ``eduroam``, ``uchicago``. The first two–``uchicago-secure`` and ``eduroam``–can be used with ``ssh``. The third–``uchicago``– DOES NOT support ``ssh`` connections.
 
    If you are on campus and have trouble logging into one of the servers, please verify that you are using either ``uchicago-secure`` or ``eduroam`` as your wireless network.  The following is a common error message that occurs when trying to use a network that does not support ``ssh`` connections : ``Could not establish connection to "linuxX.cs.uchicago.edu": The operation timed out.``
 

--- a/environment/ssh.rst
+++ b/environment/ssh.rst
@@ -42,7 +42,7 @@ On Linux, the terminal should look something like this:
 Regardless of the operating system you're using, the command prompt or terminal
 will allow you to enter text-based commands. To use SSH to connect to
 one of the UChicago CS Linux servers, you will need to type the following,
-taking care to replace ``CNETID`` with your CNetID::
+taking care to replace ``CNETID`` with your CNetID in all lowercase::
 
     ssh CNETID@linux.cs.uchicago.edu
 
@@ -60,8 +60,14 @@ print out a message like this::
 
 If so, just type ``yes``.
 
-Then, when prompted for a password, just enter your CNetID password. If your
-connection is successful, you may see a series of messages, ending with
+Then, when prompted for a password, just enter your CNetID password.
+Two troubleshooting hints:
+
+- passwords are case-sensitive, that is, upper-case ``S`` is different from lower-case ``s``.  Make sure you type your password exactly as you created it.
+
+- ``ssh`` will *not* echo your password back to you as you type it.
+
+If your connection is successful, you may see a series of messages, ending with
 this::
 
     CNETID@linuxN:~$

--- a/environment/ssh.rst
+++ b/environment/ssh.rst
@@ -60,10 +60,9 @@ print out a message like this::
 
 If so, just type ``yes``.
 
-Then, when prompted for a password, just enter your CNetID password.
-Two troubleshooting hints:
+Then, when prompted for a password, just enter your CNetID password. Here are two troubleshooting hints:
 
-- passwords are case-sensitive, that is, upper-case ``S`` is different from lower-case ``s``.  Make sure you type your password exactly as you created it.
+- passwords are case-sensitive, that is, upper-case ``S`` is different from lower-case ``s``.  Make sure you type your CNetID password exactly as you created it.
 
 - ``ssh`` will *not* echo your password back to you as you type it.
 
@@ -80,6 +79,12 @@ you should continue working on the tutorial through the SSH connection you just 
 
 When you are finished using your SSH connection, close  it by
 typing ``Ctrl-D`` or ``exit`` at the Linux prompt.
+
+.. note:: Troubleshooting UChicago Campus Network Issues
+
+   There are at least three wireless networks on campus: ``uchicago-secure``, ``eduroam``, ``uchicago``. The first two–``uchicago-secure`` and ``eduroam``–can be used with ``ssh``. The third–``uchicago``– CANNOT does not support ``ssh`` connections.
+
+   If you are on campus and have trouble logging into one of the servers, please verify that you are using either ``uchicago-secure`` or ``eduroam`` as your wireless network.  The following is a common error message that occurs when trying to use a network that does not support ``ssh`` connections : ``Could not establish connection to "linuxX.cs.uchicago.edu": The operation timed out.``
 
 
 Installing an SSH Client


### PR DESCRIPTION
I added some text to the SSH document to:

1. recommend entering the CNetID in all lower case
2. explain that passwords as case sensitive
3. explain that ssh will not echo the student's password as they type it.

This is intended to resolve issue #17.   (Is there a better way to do this?)