### PR TITLE
Network fix

### DIFF
--- a/environment/ssh.rst
+++ b/environment/ssh.rst
@@ -91,13 +91,12 @@ or ``exit`` at the Linux prompt.
 
 .. note:: Troubleshooting UChicago Campus Network Issues
 
-   There are at least three wireless networks on campus: ``uchicago-secure``,
-   ``eduroam``, ``uchicago``. The first two–``uchicago-secure`` and
-   ``eduroam``–can be used with ``ssh``. The third–``uchicago``– DOES NOT
-   support ``ssh`` connections.
+   There are at two wireless networks on campus:   ``eduroam`` and ``uchicago``.  (You may see a network named ``uchicago-secure``; it is in the process of being decommissioned.)
+
+   The first,  ``eduroam``, can be used with ``ssh``. The second, ``uchicago``,  DOES NOT    support ``ssh`` connections.
 
    If you are on campus and have trouble logging into one of the servers, please
-   verify that you are using either ``uchicago-secure`` or ``eduroam`` as your
+   verify that you are using ``eduroam`` as your
    wireless network.  The following is a common error message that occurs when
    trying to use a network that does not support ``ssh`` connections : ``Could
    not establish connection to "linuxX.cs.uchicago.edu": The operation timed


### PR DESCRIPTION
Since `uchicago-secure` is about to go away.  I deprecated it role in "Remote Access with SSH".
