### PR TITLE
Updated password-less SSH instructions to Windows to use ed25519…

### DIFF
--- a/environment/ssh.rst
+++ b/environment/ssh.rst
@@ -305,11 +305,11 @@ differ depending on whether you are using a Mac or Windows computer.
 
   ::
     
-    $publicKeyPath = "$env:USERPROFILE\\.ssh\\id_rsa.pub"
+    $publicKeyPath = "$env:USERPROFILE\.ssh\id_ed25519.pub"
     $remoteCommand = "{
         mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys
     }"
-    Get-Content $publicKeyPath | ssh <CNETID>@<servername> $remoteCommand
+    Get-Content $publicKeyPath | ssh {cnetId}@{linuxServer} $remoteCommand
   
   Replace ``<CNETID>`` with your CNetID, and ``<servername>`` with the name of the
   server you want to connect to, such as ``linux1.cs.uchicago.edu`` or

--- a/environment/ssh.rst
+++ b/environment/ssh.rst
@@ -305,11 +305,11 @@ differ depending on whether you are using a Mac or Windows computer.
 
   ::
     
-    $publicKeyPath = "$env:USERPROFILE\.ssh\id_ed25519.pub"
-    $remoteCommand = "{
-        mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys
-    }"
-    Get-Content $publicKeyPath | ssh {cnetId}@{linuxServer} $remoteCommand
+      $publicKeyPath = "$env:USERPROFILE\.ssh\id_ed25519.pub"
+      $remoteCommand = "{
+          mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys
+      }"
+      Get-Content $publicKeyPath | ssh {cnetId}@{linuxServer} $remoteCommand
   
   Replace ``<CNETID>`` with your CNetID, and ``<servername>`` with the name of the
   server you want to connect to, such as ``linux1.cs.uchicago.edu`` or


### PR DESCRIPTION
Updated password-less SSH instructions to Windows to use ed25519 instead of RSA.  Please merge and deploy.
